### PR TITLE
migrate to central workflows

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,21 +9,35 @@ on:
     - cron: "17 4 * * 1"
   workflow_dispatch:
 
-permissions:
-  actions: read
-  contents: write
-  security-events: write
-
 jobs:
-  quality:
-    uses: EnVisione/.github/.github/workflows/quality.yml@main
+  pull-request:
+    if: ${{ github.event_name == 'pull_request' }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: EnVisione/.github/.github/workflows/quality.yml@a955c949ac1e02c4311c683548f0ebd58ade9db5
     with:
-      java-version: "21"
+      shared-ref: "a955c949ac1e02c4311c683548f0ebd58ade9db5"
       gradle-enabled: true
-      gradle-tasks: "check build"
-      gametest-tasks: ""
-      node-enabled: false
-      node-version: "22"
-      codeql-languages: '["java-kotlin","javascript-typescript"]'
+      node-enabled: true
+      node-working-directory: "editor-ui"
       native-security: true
+      codeql-languages: '["java-kotlin","javascript-typescript"]'
+      enforce-docs-layout: false
+
+  trusted:
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      actions: read
+      contents: write
+      security-events: write
+    uses: EnVisione/.github/.github/workflows/quality.yml@a955c949ac1e02c4311c683548f0ebd58ade9db5
+    with:
+      shared-ref: "a955c949ac1e02c4311c683548f0ebd58ade9db5"
+      gradle-enabled: true
+      node-enabled: true
+      node-working-directory: "editor-ui"
+      native-security: true
+      codeql-languages: '["java-kotlin","javascript-typescript"]'
       enforce-docs-layout: false

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,29 @@
+name: quality
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "master"
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: write
+  security-events: write
+
+jobs:
+  quality:
+    uses: EnVisione/.github/.github/workflows/quality.yml@main
+    with:
+      java-version: "21"
+      gradle-enabled: true
+      gradle-tasks: "check build"
+      gametest-tasks: ""
+      node-enabled: false
+      node-version: "22"
+      codeql-languages: '["java-kotlin","javascript-typescript"]'
+      native-security: true
+      enforce-docs-layout: true

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -26,4 +26,4 @@ jobs:
       node-version: "22"
       codeql-languages: '["java-kotlin","javascript-typescript"]'
       native-security: true
-      enforce-docs-layout: true
+      enforce-docs-layout: false

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,34 +10,42 @@ on:
   workflow_dispatch:
 
 jobs:
-  pull-request:
-    if: ${{ github.event_name == 'pull_request' }}
+  quality:
+    permissions:
+      actions: read
+      contents: read
+    uses: EnVisione/.github/.github/workflows/quality.yml@52eb01f2a9d378693156c88e03e41dcb9f5e25bb
+    with:
+      shared-ref: "52eb01f2a9d378693156c88e03e41dcb9f5e25bb"
+      gradle-enabled: true
+      node-enabled: true
+      node-working-directory: "editor-ui"
+      native-security: true
+      enforce-docs-layout: false
+
+  codeql:
     permissions:
       actions: read
       contents: read
       security-events: write
-    uses: EnVisione/.github/.github/workflows/quality.yml@a955c949ac1e02c4311c683548f0ebd58ade9db5
+    uses: EnVisione/.github/.github/workflows/codeql.yml@52eb01f2a9d378693156c88e03e41dcb9f5e25bb
     with:
-      shared-ref: "a955c949ac1e02c4311c683548f0ebd58ade9db5"
+      shared-ref: "52eb01f2a9d378693156c88e03e41dcb9f5e25bb"
+      languages: '["java-kotlin","javascript-typescript"]'
       gradle-enabled: true
-      node-enabled: true
-      node-working-directory: "editor-ui"
-      native-security: true
-      codeql-languages: '["java-kotlin","javascript-typescript"]'
-      enforce-docs-layout: false
 
-  trusted:
-    if: ${{ github.event_name != 'pull_request' }}
+  dependency-submission:
+    if: >-
+      ${{
+        github.actor != 'dependabot[bot]' &&
+        (
+          github.event_name == 'workflow_dispatch' ||
+          (
+            github.event_name == 'push' &&
+            github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+          )
+        )
+      }}
     permissions:
-      actions: read
       contents: write
-      security-events: write
-    uses: EnVisione/.github/.github/workflows/quality.yml@a955c949ac1e02c4311c683548f0ebd58ade9db5
-    with:
-      shared-ref: "a955c949ac1e02c4311c683548f0ebd58ade9db5"
-      gradle-enabled: true
-      node-enabled: true
-      node-working-directory: "editor-ui"
-      native-security: true
-      codeql-languages: '["java-kotlin","javascript-typescript"]'
-      enforce-docs-layout: false
+    uses: EnVisione/.github/.github/workflows/dependency-submission.yml@52eb01f2a9d378693156c88e03e41dcb9f5e25bb

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -1,0 +1,24 @@
+name: release validation
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+
+jobs:
+  validate:
+    uses: EnVisione/.github/.github/workflows/release-validation.yml@main
+    with:
+      java-version: "21"
+      gradle-enabled: true
+      gradle-tasks: "clean build"
+      artifact-glob: "build/libs/*.jar"
+      sbom-path: "build/libs"
+      environment: "production"
+      attest: true

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -13,12 +13,6 @@ permissions:
 
 jobs:
   validate:
-    uses: EnVisione/.github/.github/workflows/release-validation.yml@main
+    uses: EnVisione/.github/.github/workflows/release-validation.yml@a955c949ac1e02c4311c683548f0ebd58ade9db5
     with:
-      java-version: "21"
-      gradle-enabled: true
-      gradle-tasks: "clean build"
-      artifact-glob: "build/libs/*.jar"
-      sbom-path: "build/libs"
-      environment: "production"
-      attest: true
+      shared-ref: "a955c949ac1e02c4311c683548f0ebd58ade9db5"

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -13,6 +13,6 @@ permissions:
 
 jobs:
   validate:
-    uses: EnVisione/.github/.github/workflows/release-validation.yml@a955c949ac1e02c4311c683548f0ebd58ade9db5
+    uses: EnVisione/.github/.github/workflows/release-validation.yml@52eb01f2a9d378693156c88e03e41dcb9f5e25bb
     with:
-      shared-ref: "a955c949ac1e02c4311c683548f0ebd58ade9db5"
+      shared-ref: "52eb01f2a9d378693156c88e03e41dcb9f5e25bb"


### PR DESCRIPTION
moves repository validation to the shared `EnVisione/.github` workflows.

replaces copied quality implementations with thin callers while preserving repository specific verification.

validation. caller syntax and central references were checked locally. github actions will run the complete repository verification on this pull request.
