### PR TITLE
migrate to central workflows

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,9 +17,9 @@ jobs:
     permissions:
       actions: read
       contents: read
-    uses: MCEnvision/.github/.github/workflows/quality.yml@8dad41905d6995e11688004f21c0a67462b9b5c0
+    uses: MCEnvision/.github/.github/workflows/quality.yml@853407d48c17309e2024e594e49d6dda266ac26d
     with:
-      shared-ref: "8dad41905d6995e11688004f21c0a67462b9b5c0"
+      shared-ref: "853407d48c17309e2024e594e49d6dda266ac26d"
       gradle-enabled: true
       node-enabled: true
       node-working-directory: "editor-ui"
@@ -31,9 +31,9 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: MCEnvision/.github/.github/workflows/codeql.yml@8dad41905d6995e11688004f21c0a67462b9b5c0
+    uses: MCEnvision/.github/.github/workflows/codeql.yml@853407d48c17309e2024e594e49d6dda266ac26d
     with:
-      shared-ref: "8dad41905d6995e11688004f21c0a67462b9b5c0"
+      shared-ref: "853407d48c17309e2024e594e49d6dda266ac26d"
       languages: '["java-kotlin","javascript-typescript"]'
       gradle-enabled: true
       neoforge-enabled: true
@@ -52,4 +52,4 @@ jobs:
       }}
     permissions:
       contents: write
-    uses: MCEnvision/.github/.github/workflows/dependency-submission.yml@8dad41905d6995e11688004f21c0a67462b9b5c0
+    uses: MCEnvision/.github/.github/workflows/dependency-submission.yml@853407d48c17309e2024e594e49d6dda266ac26d

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,9 +17,9 @@ jobs:
     permissions:
       actions: read
       contents: read
-    uses: MCEnvision/.github/.github/workflows/quality.yml@ec831efc8265543929ef11c5569d07d5ca095b56
+    uses: MCEnvision/.github/.github/workflows/quality.yml@e6c466f88edb57af854f597e1ce3788881d49b21
     with:
-      shared-ref: "ec831efc8265543929ef11c5569d07d5ca095b56"
+      shared-ref: "e6c466f88edb57af854f597e1ce3788881d49b21"
       gradle-enabled: true
       node-enabled: true
       node-working-directory: "editor-ui"
@@ -31,9 +31,9 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: MCEnvision/.github/.github/workflows/codeql.yml@ec831efc8265543929ef11c5569d07d5ca095b56
+    uses: MCEnvision/.github/.github/workflows/codeql.yml@e6c466f88edb57af854f597e1ce3788881d49b21
     with:
-      shared-ref: "ec831efc8265543929ef11c5569d07d5ca095b56"
+      shared-ref: "e6c466f88edb57af854f597e1ce3788881d49b21"
       languages: '["java-kotlin","javascript-typescript"]'
       gradle-enabled: true
       neoforge-enabled: true
@@ -52,4 +52,4 @@ jobs:
       }}
     permissions:
       contents: write
-    uses: MCEnvision/.github/.github/workflows/dependency-submission.yml@ec831efc8265543929ef11c5569d07d5ca095b56
+    uses: MCEnvision/.github/.github/workflows/dependency-submission.yml@e6c466f88edb57af854f597e1ce3788881d49b21

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,9 +17,9 @@ jobs:
     permissions:
       actions: read
       contents: read
-    uses: MCEnvision/.github/.github/workflows/quality.yml@2984594f1e03ee168e28c4c80701ca1e84f8cbcd
+    uses: MCEnvision/.github/.github/workflows/quality.yml@8dad41905d6995e11688004f21c0a67462b9b5c0
     with:
-      shared-ref: "2984594f1e03ee168e28c4c80701ca1e84f8cbcd"
+      shared-ref: "8dad41905d6995e11688004f21c0a67462b9b5c0"
       gradle-enabled: true
       node-enabled: true
       node-working-directory: "editor-ui"
@@ -31,9 +31,9 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: MCEnvision/.github/.github/workflows/codeql.yml@2984594f1e03ee168e28c4c80701ca1e84f8cbcd
+    uses: MCEnvision/.github/.github/workflows/codeql.yml@8dad41905d6995e11688004f21c0a67462b9b5c0
     with:
-      shared-ref: "2984594f1e03ee168e28c4c80701ca1e84f8cbcd"
+      shared-ref: "8dad41905d6995e11688004f21c0a67462b9b5c0"
       languages: '["java-kotlin","javascript-typescript"]'
       gradle-enabled: true
       neoforge-enabled: true
@@ -52,4 +52,4 @@ jobs:
       }}
     permissions:
       contents: write
-    uses: MCEnvision/.github/.github/workflows/dependency-submission.yml@2984594f1e03ee168e28c4c80701ca1e84f8cbcd
+    uses: MCEnvision/.github/.github/workflows/dependency-submission.yml@8dad41905d6995e11688004f21c0a67462b9b5c0

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,9 +17,9 @@ jobs:
     permissions:
       actions: read
       contents: read
-    uses: MCEnvision/.github/.github/workflows/quality.yml@853407d48c17309e2024e594e49d6dda266ac26d
+    uses: MCEnvision/.github/.github/workflows/quality.yml@ec831efc8265543929ef11c5569d07d5ca095b56
     with:
-      shared-ref: "853407d48c17309e2024e594e49d6dda266ac26d"
+      shared-ref: "ec831efc8265543929ef11c5569d07d5ca095b56"
       gradle-enabled: true
       node-enabled: true
       node-working-directory: "editor-ui"
@@ -31,9 +31,9 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: MCEnvision/.github/.github/workflows/codeql.yml@853407d48c17309e2024e594e49d6dda266ac26d
+    uses: MCEnvision/.github/.github/workflows/codeql.yml@ec831efc8265543929ef11c5569d07d5ca095b56
     with:
-      shared-ref: "853407d48c17309e2024e594e49d6dda266ac26d"
+      shared-ref: "ec831efc8265543929ef11c5569d07d5ca095b56"
       languages: '["java-kotlin","javascript-typescript"]'
       gradle-enabled: true
       neoforge-enabled: true
@@ -52,4 +52,4 @@ jobs:
       }}
     permissions:
       contents: write
-    uses: MCEnvision/.github/.github/workflows/dependency-submission.yml@853407d48c17309e2024e594e49d6dda266ac26d
+    uses: MCEnvision/.github/.github/workflows/dependency-submission.yml@ec831efc8265543929ef11c5569d07d5ca095b56

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,18 +5,21 @@ on:
   push:
     branches:
       - "master"
-  schedule:
-    - cron: "17 4 * * 1"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  # pinned shared quality validates gradle wrapper jars by default.
   quality:
     permissions:
       actions: read
       contents: read
-    uses: EnVisione/.github/.github/workflows/quality.yml@52eb01f2a9d378693156c88e03e41dcb9f5e25bb
+    uses: MCEnvision/.github/.github/workflows/quality.yml@2984594f1e03ee168e28c4c80701ca1e84f8cbcd
     with:
-      shared-ref: "52eb01f2a9d378693156c88e03e41dcb9f5e25bb"
+      shared-ref: "2984594f1e03ee168e28c4c80701ca1e84f8cbcd"
       gradle-enabled: true
       node-enabled: true
       node-working-directory: "editor-ui"
@@ -28,11 +31,12 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: EnVisione/.github/.github/workflows/codeql.yml@52eb01f2a9d378693156c88e03e41dcb9f5e25bb
+    uses: MCEnvision/.github/.github/workflows/codeql.yml@2984594f1e03ee168e28c4c80701ca1e84f8cbcd
     with:
-      shared-ref: "52eb01f2a9d378693156c88e03e41dcb9f5e25bb"
+      shared-ref: "2984594f1e03ee168e28c4c80701ca1e84f8cbcd"
       languages: '["java-kotlin","javascript-typescript"]'
       gradle-enabled: true
+      neoforge-enabled: true
 
   dependency-submission:
     if: >-
@@ -48,4 +52,4 @@ jobs:
       }}
     permissions:
       contents: write
-    uses: EnVisione/.github/.github/workflows/dependency-submission.yml@52eb01f2a9d378693156c88e03e41dcb9f5e25bb
+    uses: MCEnvision/.github/.github/workflows/dependency-submission.yml@2984594f1e03ee168e28c4c80701ca1e84f8cbcd

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   validate:
-    uses: MCEnvision/.github/.github/workflows/release-validation.yml@ec831efc8265543929ef11c5569d07d5ca095b56
+    uses: MCEnvision/.github/.github/workflows/release-validation.yml@e6c466f88edb57af854f597e1ce3788881d49b21
     with:
-      shared-ref: "ec831efc8265543929ef11c5569d07d5ca095b56"
+      shared-ref: "e6c466f88edb57af854f597e1ce3788881d49b21"

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   validate:
-    uses: MCEnvision/.github/.github/workflows/release-validation.yml@2984594f1e03ee168e28c4c80701ca1e84f8cbcd
+    uses: MCEnvision/.github/.github/workflows/release-validation.yml@8dad41905d6995e11688004f21c0a67462b9b5c0
     with:
-      shared-ref: "2984594f1e03ee168e28c4c80701ca1e84f8cbcd"
+      shared-ref: "8dad41905d6995e11688004f21c0a67462b9b5c0"

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   validate:
-    uses: MCEnvision/.github/.github/workflows/release-validation.yml@8dad41905d6995e11688004f21c0a67462b9b5c0
+    uses: MCEnvision/.github/.github/workflows/release-validation.yml@853407d48c17309e2024e594e49d6dda266ac26d
     with:
-      shared-ref: "8dad41905d6995e11688004f21c0a67462b9b5c0"
+      shared-ref: "853407d48c17309e2024e594e49d6dda266ac26d"

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   validate:
-    uses: MCEnvision/.github/.github/workflows/release-validation.yml@853407d48c17309e2024e594e49d6dda266ac26d
+    uses: MCEnvision/.github/.github/workflows/release-validation.yml@ec831efc8265543929ef11c5569d07d5ca095b56
     with:
-      shared-ref: "853407d48c17309e2024e594e49d6dda266ac26d"
+      shared-ref: "ec831efc8265543929ef11c5569d07d5ca095b56"

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -6,6 +6,10 @@ on:
       - "v*"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write
@@ -13,6 +17,6 @@ permissions:
 
 jobs:
   validate:
-    uses: EnVisione/.github/.github/workflows/release-validation.yml@52eb01f2a9d378693156c88e03e41dcb9f5e25bb
+    uses: MCEnvision/.github/.github/workflows/release-validation.yml@2984594f1e03ee168e28c4c80701ca1e84f8cbcd
     with:
-      shared-ref: "52eb01f2a9d378693156c88e03e41dcb9f5e25bb"
+      shared-ref: "2984594f1e03ee168e28c4c80701ca1e84f8cbcd"


### PR DESCRIPTION
moves repository validation to the shared `MCEnvision/.github` workflows.

replaces copied quality implementations with thin callers while preserving repository specific verification.

validation. caller syntax and central references were checked locally. github actions will run the complete repository verification on this pull request.
