### PR TITLE
migrate to central workflows

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,9 +17,9 @@ jobs:
     permissions:
       actions: read
       contents: read
-    uses: MCEnvision/.github/.github/workflows/quality.yml@e6c466f88edb57af854f597e1ce3788881d49b21
+    uses: MCEnvision/.github/.github/workflows/quality.yml@d731214d860ad2422ab8956a5d337dfaec51f64a
     with:
-      shared-ref: "e6c466f88edb57af854f597e1ce3788881d49b21"
+      shared-ref: "d731214d860ad2422ab8956a5d337dfaec51f64a"
       gradle-enabled: true
       node-enabled: true
       node-working-directory: "editor-ui"
@@ -31,9 +31,9 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: MCEnvision/.github/.github/workflows/codeql.yml@e6c466f88edb57af854f597e1ce3788881d49b21
+    uses: MCEnvision/.github/.github/workflows/codeql.yml@d731214d860ad2422ab8956a5d337dfaec51f64a
     with:
-      shared-ref: "e6c466f88edb57af854f597e1ce3788881d49b21"
+      shared-ref: "d731214d860ad2422ab8956a5d337dfaec51f64a"
       languages: '["java-kotlin","javascript-typescript"]'
       gradle-enabled: true
       neoforge-enabled: true
@@ -52,4 +52,4 @@ jobs:
       }}
     permissions:
       contents: write
-    uses: MCEnvision/.github/.github/workflows/dependency-submission.yml@e6c466f88edb57af854f597e1ce3788881d49b21
+    uses: MCEnvision/.github/.github/workflows/dependency-submission.yml@d731214d860ad2422ab8956a5d337dfaec51f64a

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   validate:
-    uses: MCEnvision/.github/.github/workflows/release-validation.yml@e6c466f88edb57af854f597e1ce3788881d49b21
+    uses: MCEnvision/.github/.github/workflows/release-validation.yml@d731214d860ad2422ab8956a5d337dfaec51f64a
     with:
-      shared-ref: "e6c466f88edb57af854f597e1ce3788881d49b21"
+      shared-ref: "d731214d860ad2422ab8956a5d337dfaec51f64a"


### PR DESCRIPTION
moves repository validation to the shared `MCEnvision/.github` workflows.

replaces copied quality implementations with thin callers while preserving repository specific verification.

validation. caller syntax and central references were checked locally. github actions will run the complete repository verification on this pull request.
