### PR TITLE
phase 004 compatibility evidence

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -3680,6 +3680,11 @@ viewer is installed; plugins are loaded only when the corresponding mod is prese
 > JEI side already guards `NoClassDefFoundError`. See
 > [`ClientLockCache`](src/main/java/com/enviouse/progressivestages/client/ClientLockCache.java).
 
+> **Fixed in 3.0.4:** an EMI visibility refresh is cancelled when the client begins disconnecting.
+> This prevents a stage or lock cache clear during world exit from starting an EMI worker after the
+> client level has been released. The guard is reset for the next server connection, so normal
+> stage grants, revokes, and lock snapshot changes still refresh EMI during active play.
+
 ### 8.1 Visual treatment
 
 The integrations are enabled independently with `[jei].enabled` and `[emi].enabled`. The three

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ schema 4 showcase now demonstrates the editor and class tree directly.
 - **Category menu foreground repair.** The open progression map category list now renders above
   every stage frame and item icon, including nodes positioned directly beneath the menu. Category
   selection, scrolling, filtering, graph movement, zoom, and the pinned inspector are unchanged.
+- **Safe EMI world exit.** An EMI refresh now stops at the client disconnect boundary. Leaving a
+  world with EMI installed cannot start a reload after the client level has closed.
 - **World generation safe structure rules.** Structure aware entity decisions use an immutable
   server published session snapshot during asynchronous chunk generation. Ocean ruins and similar
   structures no longer call server thread only session state from a chunk worker.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Use this page to find the maintained project documentation.
 
 - [3.0.4 entity presence fixture](verification/3.0.4-entity-presence-fixture.md)
 - [3.0.4 optional integration artifact and runtime evidence](verification/3.0.4-optional-integration-artifacts.md)
+- [3.0.4 phase 004 compatibility candidate](verification/3.0.4-phase-004-compatibility.md)
 - [Editor rehaul phase 1](verification/REHAUL_PHASE_1.md)
 - [Editor rehaul phases 2 through 22](verification/REHAUL_PHASES_2_TO_22.md)
 

--- a/docs/release/3.0.4.md
+++ b/docs/release/3.0.4.md
@@ -45,6 +45,8 @@ after the final release artifact is approved.
 - Java 21.
 - Existing stage packages remain supported. The new inventory rule is additive
   and has no effect unless a stage declares it.
+- EMI refreshes stop at the client disconnect boundary, preventing a world exit
+  from starting an EMI reload after the client level is gone.
 
 For setup and examples, see [the complete documentation](../../DOCUMENTATION.md)
 and [inventory insertion rules](../features/inventory-insertion.md).

--- a/docs/verification/3.0.4-optional-integration-artifacts.md
+++ b/docs/verification/3.0.4-optional-integration-artifacts.md
@@ -59,13 +59,17 @@ combination. Full in-world viewer interaction remains a manual follow-up at the 
 
 ## Packaged Artifact Check
 
-`./gradlew build` produced `build/libs/progressivestages-3.0.3.jar` with SHA-256
+The Phase 002 historical candidate was `build/libs/progressivestages-3.0.3.jar` with SHA-256
 `39ff5a95d2f33abd98f930dfb30e846e6f8c060196422b5aa6f66ad6d4192fac` and SHA-512
 `eb4a44996f026c26600b29a586ccc2479c115dd49c934b01a131308c29f49c5b639250d6e51e82da6393e11f4eb6b39442931054552b729fd1782eea0027f15f`.
 `unzip -tq` passed. The JAR contains ProgressiveStages Curios, JEI, and EMI adapter classes and
 the packaged editor assets. Its entry list contains no `top/theillusivec4/curios`, `mezz/jei`, or
 `dev/emi` implementation classes, so the supported integrations remain optional rather than bundled
 dependencies.
+
+The superseding integrated 3.0.4 candidate, its packaged client and dedicated-server smoke tests,
+and its world-exit EMI regression check are recorded in
+[`3.0.4-phase-004-compatibility.md`](3.0.4-phase-004-compatibility.md).
 
 This record covers the final local integration matrix and package inspection for Phase 002. The
 phase still requires its pull-request verification, merge, and signed phase-tag gate defined in

--- a/docs/verification/3.0.4-phase-004-compatibility.md
+++ b/docs/verification/3.0.4-phase-004-compatibility.md
@@ -1,0 +1,106 @@
+# 3.0.4 Phase 004 Compatibility Candidate
+
+**Phase:** `CORE-PHASE-004`  
+**Requirement:** `CORE-REQ-008`  
+**Candidate code revision:** `237b1e0f9a4137c4fccf9a008e9c2aacd6c7f149`  
+**Platform:** Minecraft `1.21.1`, NeoForge `21.1.219`, Java `21.0.11`
+
+This is a revision-bound compatibility record for the Phase 004 candidate. It is not a release
+approval, platform upload, or issue closure. The six baseline issues remain open until the final
+release phase has verified the signed release artifact.
+
+## Candidate identity
+
+| Item | Verified value |
+| --- | --- |
+| JAR | `build/libs/progressivestages-3.0.4.jar` |
+| SHA-256 | `97074dbe7191a6517803aa820c9bd1d0e167eb3581ee9884090a594c90c130ce` |
+| SHA-512 | `229fb35fa691dcbbac22ff6dc2d372eef7efc512f28a4a9ace99519135058d38432ca1933121bd695093b29954d60dfbd0e28509f71bb0b6304dfdd0a5de62f0` |
+| Embedded mod metadata | `progressivestages`, version `3.0.4`, logo `progressivestages.png` |
+| Editor bundle SHA-256 | `3565aeeadf73640c3eea83f826fc39ed1ac748016201429316c017f6f16b7459` |
+
+The JAR contains the EMI adapter, inventory-insertion enforcer and GameTests, NeoForge mod
+metadata, and the production editor bundle. The editor bundle hash inside the JAR matches the
+resource tree hash. The JAR does not package Curios, JEI, or EMI implementation classes.
+
+## Upstream phase lineage
+
+The candidate descends from the merged and signed Phase 001, Phase 002, and Phase 003 work. The
+following signed tags were verified before this candidate was exercised:
+
+| Phase | Signed tag | Tagged merged revision |
+| --- | --- | --- |
+| Entity presence | `3.0.4-phase-001` | `09b18ad5b91a8c5b59faf1d35821f5c786427b80` |
+| Optional integrations | `3.0.4-phase-002` | `1cc3d5e6d7227a147b2096c8b85253b083b57a2a` |
+| Editor, recipe, inventory, and UI work | `3.0.4-phase-003` | `b9391dc00c8d410286a5e0f61a3213a014e05416` |
+
+## Verification results
+
+| Boundary | Procedure | Result |
+| --- | --- | --- |
+| Java tests | `./gradlew --rerun-tasks test` | Passed. 222 tests, 0 failures, 0 errors. |
+| GameTests | `./gradlew --rerun-tasks runGameTestServer` | Passed. All 20 required GameTests passed on NeoForge 21.1.219. |
+| Full build | `./gradlew --rerun-tasks build` | Passed with Java 21. |
+| Editor project | `npm test`, `npm run check`, `npm run build` in `editor-ui` | Passed. 20 tests passed, TypeScript check passed, and the production bundle rebuilt. |
+| Packaged dedicated server | Clean NeoForge 21.1.219 server with only the candidate plus Curios, JEI, and EMI fixture artifacts | Passed. Loaded 50 stages, activated the Curios adapter, reached world readiness, and stopped cleanly. |
+| Packaged client | Clean NeoForge client with only the candidate plus Curios, JEI, and EMI fixture artifacts | Passed. Reached the title screen and an integrated world, loaded all 50 stages, opened the inventory map button, opened the stage map, used category selection, pan, zoom, and the stage inspector. |
+| Category overlay | Packaged client category list opened over populated stage nodes | Passed. Stage item icons remained below the open category menu and its input capture. |
+| Editor authority and launch | `/pstages editor` from an operator integrated world | Passed. The server opened the authenticated loopback editor session. The headless fixture had no desktop opener, so only the authenticated launch path, not an external browser process, was exercised. |
+| World exit with EMI | Entered and left an integrated world with Curios, JEI, and EMI installed | Passed after the candidate fix. No ProgressiveStages-triggered EMI reload or null client-level exception occurred during disconnect. |
+
+The dedicated and client tests used the exact public fixture artifacts documented in
+[`3.0.4-optional-integration-artifacts.md`](3.0.4-optional-integration-artifacts.md). The client
+workflow found a disconnect race where cache cleanup could begin an EMI reload after a world exit.
+The candidate marks the disconnect boundary before cache cleanup, cancels pending work, and reopens
+the refresh path only after the next client login. `ProgressiveStagesEMIPluginTest` guards that
+ordering, and the packaged-client world-exit workflow reproduced the original transition after the
+fix.
+
+## Schema, enforcement, and compatibility coverage
+
+The passing Java and GameTest suites cover existing stage parsing, namespaced `pack:stage`
+identifiers, trailing command whitespace, immutable synced snapshots, independent JEI and EMI
+settings, absent optional dependencies, Curios API resolution, canonical recipe fields, legacy
+recipe draft migration or rejection, inventory insertion selector pairing, target resolver identity,
+priority exceptions, player-origin boundaries, inventory transaction conservation, and the complete
+client map render and input stack.
+
+The GameTest run includes inventory insertion coverage and reports all required tests as passing.
+The Java suite additionally verifies parser rejection before mutation, atomic editor draft handling,
+server-side authorization, loopback request guards, and stable selector and resolver behavior.
+These automated fixtures are the compatibility proof for server transaction details; the packaged
+client smoke supplies the separate installed-artifact UI and lifecycle proof.
+
+## Security review
+
+The review found no confirmed candidate security defect. The loopback editor remains bound to the
+local host and validates host, origin, and session authentication before serving drafts. Editor
+apply validates managed paths, limits request sizes, writes atomically, and keeps the prior valid
+state on a rejected draft. Server mutation remains permission checked and server authoritative.
+Optional integrations are protected by optional loading boundaries and were verified on a dedicated
+server without client-only classloading.
+
+No credentials, confirmation values, world data, or player identifiers are stored in this record.
+
+## Baseline issue closure packets, draft only
+
+| Issue | Candidate evidence | Owning signed phase | Status |
+| --- | --- | --- | --- |
+| #8, Curios slot locking | Curios public API fixture, absent-mod boundary, dedicated-server adapter startup, and packaged JAR inspection | Phase 002 | Open pending final release evidence. |
+| #10, JEI with EMI | Independent viewer settings, combined client startup, and packaged client smoke | Phase 002 | Open pending final release evidence. |
+| #11, enchantment controls | Production editor bundle test, TypeScript check, bundle inspection, and packaged editor asset inspection | Phase 003 | Open pending final release evidence. |
+| #16, category menu depth | Render-order tests and the packaged client overlay workflow | Phase 003 | Open pending final release evidence. |
+| #24, entity presence cost | Phase 001 signed performance fixture and integrated regression suite | Phase 001 | Open pending final release evidence. |
+| #25, recipe serialization | Canonical-field parser and editor transaction tests, package inspection, and the Phase 003 integration lineage | Phase 003 | Open pending final release evidence. |
+
+`CORE-REQ-012` inventory insertion is represented by the compatibility evidence above and is not a
+seventh issue packet.
+
+## Recovery and invalidation
+
+If a replacement candidate is required, preserve the affected world and
+`config/progressivestages` directory, restore the last accepted JAR, restart the server, and verify
+persisted stage ownership before applying another editor draft. Any Java, resource, dependency, or
+build-metadata change requires a new JAR hash and reruns the affected tests, GameTests, packaged
+server smoke, packaged client smoke, and final JAR inspection. This candidate supersedes the prior
+Phase 002 packaged-artifact identity only for Phase 004 compatibility evidence.

--- a/docs/verification/3.0.4-phase-004-compatibility.md
+++ b/docs/verification/3.0.4-phase-004-compatibility.md
@@ -2,7 +2,7 @@
 
 **Phase:** `CORE-PHASE-004`
 **Requirement:** `CORE-REQ-008`
-**Candidate code revision:** `771fef2dcaf9c3a6251567dc6d425f33675fc314`
+**Candidate code revision:** `69089dd9d0fd6d8258d107516eaea00b68007f49`
 **Platform:** Minecraft `1.21.1`, NeoForge `21.1.219`, Java `21.0.11`
 
 This is a revision-bound compatibility record for the Phase 004 candidate. It is not a release
@@ -14,8 +14,8 @@ release phase has verified the signed release artifact.
 | Item | Verified value |
 | --- | --- |
 | JAR | `build/libs/progressivestages-3.0.4.jar` |
-| SHA-256 | `9f257b3d7ec0aad1f1107e6ba010a23a614dd7cb7ec7dd7ae15c24848922083a` |
-| SHA-512 | `4a7845e301216429a6aee88648be89079342fa3658715f6da04957b6ce4de2b6dad2d3f05fa56f320c1a9e671a017675e279bf3163e96f6d5c48375c760a5aa4` |
+| SHA-256 | `f96ce6b1f442ec280270dae5cee7cd220113991109e1007d82666c2713dd8285` |
+| SHA-512 | `ceb0fc59f1808fe03a4dc4bf3a82d45983acb767504eecf0c698ef4ea3fccdcd8bf033b274cda28bf489ac20e7ae65275533a7c6f33ecd7f6d401f83f3f2b806` |
 | Embedded mod metadata | `progressivestages`, version `3.0.4`, logo `progressivestages.png` |
 | Editor bundle SHA-256 | `3565aeeadf73640c3eea83f826fc39ed1ac748016201429316c017f6f16b7459` |
 

--- a/docs/verification/3.0.4-phase-004-compatibility.md
+++ b/docs/verification/3.0.4-phase-004-compatibility.md
@@ -2,7 +2,7 @@
 
 **Phase:** `CORE-PHASE-004`
 **Requirement:** `CORE-REQ-008`
-**Candidate code revision:** `91e5b3d4e513b9d9528f5958b8dc53bd271d4ac6`
+**Candidate code revision:** `771fef2dcaf9c3a6251567dc6d425f33675fc314`
 **Platform:** Minecraft `1.21.1`, NeoForge `21.1.219`, Java `21.0.11`
 
 This is a revision-bound compatibility record for the Phase 004 candidate. It is not a release
@@ -14,8 +14,8 @@ release phase has verified the signed release artifact.
 | Item | Verified value |
 | --- | --- |
 | JAR | `build/libs/progressivestages-3.0.4.jar` |
-| SHA-256 | `e1d05f70877b4ce7e3b234f7ce76a595b9244dbb60a84f40cecd825b1079c58f` |
-| SHA-512 | `2582da254c70fff39ed25fc75ffcff91dbf9f4c11650e68f91b1cb196f0bbeec1478641fca5018dd7f2900f8e79622228b6cfc4782a7f733a3f4567d776a26fc` |
+| SHA-256 | `9f257b3d7ec0aad1f1107e6ba010a23a614dd7cb7ec7dd7ae15c24848922083a` |
+| SHA-512 | `4a7845e301216429a6aee88648be89079342fa3658715f6da04957b6ce4de2b6dad2d3f05fa56f320c1a9e671a017675e279bf3163e96f6d5c48375c760a5aa4` |
 | Embedded mod metadata | `progressivestages`, version `3.0.4`, logo `progressivestages.png` |
 | Editor bundle SHA-256 | `3565aeeadf73640c3eea83f826fc39ed1ac748016201429316c017f6f16b7459` |
 
@@ -44,6 +44,7 @@ following signed tags were verified before this candidate was exercised:
 | Editor project | `npm test`, `npm run check`, `npm run build` in `editor-ui` | Passed. 20 tests passed, TypeScript check passed, and the production bundle rebuilt. |
 | Packaged dedicated server | Clean NeoForge 21.1.219 server with only the candidate plus Curios, JEI, and EMI fixture artifacts | Passed. Loaded 50 stages, activated the Curios adapter, reached world readiness, and stopped cleanly. |
 | Packaged client | Clean NeoForge client with only the candidate plus Curios, JEI, and EMI fixture artifacts | Passed. Reached the title screen and an integrated world, loaded all 50 stages, opened the inventory map button, opened the stage map, used category selection, pan, zoom, and the stage inspector. |
+| Packaged client without EMI | Clean NeoForge client with the candidate, Curios, and JEI only | Passed. Reached the title screen and initialized ProgressiveStages without EMI classes or linkage errors. |
 | Category overlay | Packaged client category list opened over populated stage nodes | Passed. Stage item icons remained below the open category menu and its input capture. |
 | Editor authority and launch | `/pstages editor` from an operator integrated world | Passed. The server opened the authenticated loopback editor session. The headless fixture had no desktop opener, so only the authenticated launch path, not an external browser process, was exercised. |
 | World exit with EMI | Entered and left an integrated world with Curios, JEI, and EMI installed | Passed after the candidate fix. No ProgressiveStages-triggered EMI reload or null client-level exception occurred during disconnect. |
@@ -55,6 +56,11 @@ The candidate marks the disconnect boundary before cache cleanup, cancels pendin
 the refresh path only after the next client login. `ProgressiveStagesEMIPluginTest` guards that
 ordering, and the packaged-client world-exit workflow reproduced the original transition after the
 fix.
+
+The regular login and logout event handlers do not directly link the EMI plugin class. An
+EMI-free lifecycle bridge first confirms that EMI is installed, then resolves the optional plugin
+reflectively. This keeps normal client lifecycle events safe when EMI is absent while retaining the
+disconnect protection when it is installed.
 
 ## Schema, enforcement, and compatibility coverage
 

--- a/docs/verification/3.0.4-phase-004-compatibility.md
+++ b/docs/verification/3.0.4-phase-004-compatibility.md
@@ -2,7 +2,7 @@
 
 **Phase:** `CORE-PHASE-004`  
 **Requirement:** `CORE-REQ-008`  
-**Candidate code revision:** `237b1e0f9a4137c4fccf9a008e9c2aacd6c7f149`  
+**Candidate code revision:** `91e5b3d4e513b9d9528f5958b8dc53bd271d4ac6`
 **Platform:** Minecraft `1.21.1`, NeoForge `21.1.219`, Java `21.0.11`
 
 This is a revision-bound compatibility record for the Phase 004 candidate. It is not a release
@@ -14,8 +14,8 @@ release phase has verified the signed release artifact.
 | Item | Verified value |
 | --- | --- |
 | JAR | `build/libs/progressivestages-3.0.4.jar` |
-| SHA-256 | `97074dbe7191a6517803aa820c9bd1d0e167eb3581ee9884090a594c90c130ce` |
-| SHA-512 | `229fb35fa691dcbbac22ff6dc2d372eef7efc512f28a4a9ace99519135058d38432ca1933121bd695093b29954d60dfbd0e28509f71bb0b6304dfdd0a5de62f0` |
+| SHA-256 | `e1d05f70877b4ce7e3b234f7ce76a595b9244dbb60a84f40cecd825b1079c58f` |
+| SHA-512 | `2582da254c70fff39ed25fc75ffcff91dbf9f4c11650e68f91b1cb196f0bbeec1478641fca5018dd7f2900f8e79622228b6cfc4782a7f733a3f4567d776a26fc` |
 | Embedded mod metadata | `progressivestages`, version `3.0.4`, logo `progressivestages.png` |
 | Editor bundle SHA-256 | `3565aeeadf73640c3eea83f826fc39ed1ac748016201429316c017f6f16b7459` |
 

--- a/docs/verification/3.0.4-phase-004-compatibility.md
+++ b/docs/verification/3.0.4-phase-004-compatibility.md
@@ -2,7 +2,7 @@
 
 **Phase:** `CORE-PHASE-004`
 **Requirement:** `CORE-REQ-008`
-**Candidate code revision:** `69089dd9d0fd6d8258d107516eaea00b68007f49`
+**Candidate code revision:** `98cc7fbd98ffb565284dce00224b3fb0dba2c266`
 **Platform:** Minecraft `1.21.1`, NeoForge `21.1.219`, Java `21.0.11`
 
 This is a revision-bound compatibility record for the Phase 004 candidate. It is not a release
@@ -14,8 +14,8 @@ release phase has verified the signed release artifact.
 | Item | Verified value |
 | --- | --- |
 | JAR | `build/libs/progressivestages-3.0.4.jar` |
-| SHA-256 | `f96ce6b1f442ec280270dae5cee7cd220113991109e1007d82666c2713dd8285` |
-| SHA-512 | `ceb0fc59f1808fe03a4dc4bf3a82d45983acb767504eecf0c698ef4ea3fccdcd8bf033b274cda28bf489ac20e7ae65275533a7c6f33ecd7f6d401f83f3f2b806` |
+| SHA-256 | `3969697920a9c2e0f26da2cdee78d97460d8c69f4818aeae1037d22f4240395b` |
+| SHA-512 | `cb8b7a94be931667694b805f1869d31e6afacdf6bbc4d91d47712bb25da8f331222fd8993f783150aae6f09d834669c4f87e6b476c7dd0acde3ffbf0b12a3f97` |
 | Embedded mod metadata | `progressivestages`, version `3.0.4`, logo `progressivestages.png` |
 | Editor bundle SHA-256 | `3565aeeadf73640c3eea83f826fc39ed1ac748016201429316c017f6f16b7459` |
 
@@ -44,7 +44,7 @@ following signed tags were verified before this candidate was exercised:
 | Editor project | `npm test`, `npm run check`, `npm run build` in `editor-ui` | Passed. 20 tests passed, TypeScript check passed, and the production bundle rebuilt. |
 | Packaged dedicated server | Clean NeoForge 21.1.219 server with only the candidate plus Curios, JEI, and EMI fixture artifacts | Passed. Loaded 50 stages, activated the Curios adapter, reached world readiness, and stopped cleanly. |
 | Packaged client | Clean NeoForge client with only the candidate plus Curios, JEI, and EMI fixture artifacts | Passed. Reached the title screen and an integrated world, loaded all 50 stages, opened the inventory map button, opened the stage map, used category selection, pan, zoom, and the stage inspector. |
-| Packaged client without EMI | Clean NeoForge client with the candidate, Curios, and JEI only | Passed. Reached the title screen and initialized ProgressiveStages without EMI classes or linkage errors. |
+| Packaged client without EMI | Clean NeoForge client with the candidate, Curios, and JEI only | Passed. Started and initialized ProgressiveStages without EMI classes, linkage errors, or optional-plugin resolution failures. |
 | Category overlay | Packaged client category list opened over populated stage nodes | Passed. Stage item icons remained below the open category menu and its input capture. |
 | Editor authority and launch | `/pstages editor` from an operator integrated world | Passed. The server opened the authenticated loopback editor session. The headless fixture had no desktop opener, so only the authenticated launch path, not an external browser process, was exercised. |
 | World exit with EMI | Entered and left an integrated world with Curios, JEI, and EMI installed | Passed after the candidate fix. No ProgressiveStages-triggered EMI reload or null client-level exception occurred during disconnect. |
@@ -53,9 +53,11 @@ The dedicated and client tests used the exact public fixture artifacts documente
 [`3.0.4-optional-integration-artifacts.md`](3.0.4-optional-integration-artifacts.md). The client
 workflow found a disconnect race where cache cleanup could begin an EMI reload after a world exit.
 The candidate marks the disconnect boundary before cache cleanup, cancels pending work, and reopens
-the refresh path only after the next client login. `ProgressiveStagesEMIPluginTest` guards that
-ordering, and the packaged-client world-exit workflow reproduced the original transition after the
-fix.
+the refresh path only after the next client login. Every queued EMI refresh now captures the active
+client-session generation. Beginning a disconnect advances that generation, so a task queued for an
+old world cannot reload EMI after a later login. `ProgressiveStagesEMIPluginTest` guards both the
+lifecycle ordering and the session-generation boundary, and the packaged-client world-exit workflow
+reproduced the original transition after the fix.
 
 The regular login and logout event handlers do not directly link the EMI plugin class. An
 EMI-free lifecycle bridge first confirms that EMI is installed, then resolves the optional plugin

--- a/docs/verification/3.0.4-phase-004-compatibility.md
+++ b/docs/verification/3.0.4-phase-004-compatibility.md
@@ -1,7 +1,7 @@
 # 3.0.4 Phase 004 Compatibility Candidate
 
-**Phase:** `CORE-PHASE-004`  
-**Requirement:** `CORE-REQ-008`  
+**Phase:** `CORE-PHASE-004`
+**Requirement:** `CORE-REQ-008`
 **Candidate code revision:** `91e5b3d4e513b9d9528f5958b8dc53bd271d4ac6`
 **Platform:** Minecraft `1.21.1`, NeoForge `21.1.219`, Java `21.0.11`
 

--- a/src/main/java/com/enviouse/progressivestages/client/ClientEventHandler.java
+++ b/src/main/java/com/enviouse/progressivestages/client/ClientEventHandler.java
@@ -158,7 +158,7 @@ public class ClientEventHandler {
     /** Prevent lock and progression snapshots from leaking between multiplayer servers/worlds. */
     @SubscribeEvent
     public static void onClientLogout(ClientPlayerNetworkEvent.LoggingOut event) {
-        com.enviouse.progressivestages.client.emi.ProgressiveStagesEMIPlugin.beginClientDisconnect();
+        EmiLifecycleBridge.beginClientDisconnect();
         ClientStageCache.clear();
         ClientTriggerProgress.clear();
         ClientUnlockJuice.clear();
@@ -173,7 +173,7 @@ public class ClientEventHandler {
     /** Re-enable recipe-viewer refreshes after a previous server disconnect. */
     @SubscribeEvent
     public static void onClientLogin(ClientPlayerNetworkEvent.LoggingIn event) {
-        com.enviouse.progressivestages.client.emi.ProgressiveStagesEMIPlugin.endClientDisconnect();
+        EmiLifecycleBridge.endClientDisconnect();
     }
 
     /** v2.3: poll the stage-tree keybind; request a progress snapshot, which opens the GUI. */

--- a/src/main/java/com/enviouse/progressivestages/client/ClientEventHandler.java
+++ b/src/main/java/com/enviouse/progressivestages/client/ClientEventHandler.java
@@ -158,6 +158,7 @@ public class ClientEventHandler {
     /** Prevent lock and progression snapshots from leaking between multiplayer servers/worlds. */
     @SubscribeEvent
     public static void onClientLogout(ClientPlayerNetworkEvent.LoggingOut event) {
+        com.enviouse.progressivestages.client.emi.ProgressiveStagesEMIPlugin.beginClientDisconnect();
         ClientStageCache.clear();
         ClientTriggerProgress.clear();
         ClientUnlockJuice.clear();
@@ -167,6 +168,12 @@ public class ClientEventHandler {
         OreSpoofClientState.clear();
         ClientCompiledSnapshotCache.clear();
         com.enviouse.progressivestages.client.editor.LoopbackEditorBridge.closeActive();
+    }
+
+    /** Re-enable recipe-viewer refreshes after a previous server disconnect. */
+    @SubscribeEvent
+    public static void onClientLogin(ClientPlayerNetworkEvent.LoggingIn event) {
+        com.enviouse.progressivestages.client.emi.ProgressiveStagesEMIPlugin.endClientDisconnect();
     }
 
     /** v2.3: poll the stage-tree keybind; request a progress snapshot, which opens the GUI. */

--- a/src/main/java/com/enviouse/progressivestages/client/EmiLifecycleBridge.java
+++ b/src/main/java/com/enviouse/progressivestages/client/EmiLifecycleBridge.java
@@ -1,0 +1,33 @@
+package com.enviouse.progressivestages.client;
+
+import com.mojang.logging.LogUtils;
+import net.neoforged.fml.ModList;
+import org.slf4j.Logger;
+
+/**
+ * Invokes the optional EMI lifecycle hooks without linking the normal client event path to EMI.
+ */
+public final class EmiLifecycleBridge {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    private static final String EMI_PLUGIN =
+        "com.enviouse.progressivestages.client.emi.ProgressiveStagesEMIPlugin";
+
+    private EmiLifecycleBridge() {}
+
+    public static void beginClientDisconnect() {
+        invoke("beginClientDisconnect");
+    }
+
+    public static void endClientDisconnect() {
+        invoke("endClientDisconnect");
+    }
+
+    private static void invoke(String methodName) {
+        if (!ModList.get().isLoaded("emi")) return;
+        try {
+            Class.forName(EMI_PLUGIN).getMethod(methodName).invoke(null);
+        } catch (ReflectiveOperationException | LinkageError error) {
+            LOGGER.debug("[ProgressiveStages] EMI lifecycle bridge was unavailable", error);
+        }
+    }
+}

--- a/src/main/java/com/enviouse/progressivestages/client/emi/ProgressiveStagesEMIPlugin.java
+++ b/src/main/java/com/enviouse/progressivestages/client/emi/ProgressiveStagesEMIPlugin.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * EMI plugin entrypoint for ProgressiveStages
@@ -43,6 +44,7 @@ public class ProgressiveStagesEMIPlugin implements EmiPlugin {
     // Prevent rapid-fire reloads; only allow one pending reload at a time
     private static final AtomicBoolean reloadPending = new AtomicBoolean(false);
     private static final AtomicBoolean clientDisconnecting = new AtomicBoolean(false);
+    private static final AtomicLong clientSessionGeneration = new AtomicLong();
 
     @Override
     public void register(EmiRegistry registry) {
@@ -379,6 +381,7 @@ public class ProgressiveStagesEMIPlugin implements EmiPlugin {
      * (not a server-driven tag+recipe resync), reload() bypasses that gate.
      */
     public static void triggerEmiReload() {
+        long refreshGeneration = clientSessionGeneration.get();
         if (!StageConfig.isEmiEnabled()) {
             return;
         }
@@ -402,8 +405,9 @@ public class ProgressiveStagesEMIPlugin implements EmiPlugin {
             // Schedule on the main render thread with a small delay to let data settle
             minecraft.execute(() -> {
                 try {
+                    if (!isCurrentSession(refreshGeneration, minecraft)) return;
                     reloadPending.set(false);
-                    if (clientDisconnecting.get() || !isReloadableClient(minecraft)) return;
+                    if (!isCurrentSession(refreshGeneration, minecraft)) return;
                     LOGGER.info("[ProgressiveStages] Triggering EMI reload. Current stages: {}", ClientStageCache.getStages());
 
                     // Use EmiReloadManager.reload() directly to force a full EMI reload.
@@ -417,12 +421,12 @@ public class ProgressiveStagesEMIPlugin implements EmiPlugin {
 
                     LOGGER.info("[ProgressiveStages] EMI reload triggered successfully");
                 } catch (Exception e) {
-                    reloadPending.set(false);
+                    clearPendingForCurrentSession(refreshGeneration);
                     LOGGER.error("[ProgressiveStages] Failed to trigger EMI reload: {}", e.getMessage());
                 }
             });
         } catch (Exception e) {
-            reloadPending.set(false);
+            clearPendingForCurrentSession(refreshGeneration);
             LOGGER.error("[ProgressiveStages] Failed to schedule EMI reload: {}", e.getMessage());
         }
     }
@@ -430,6 +434,7 @@ public class ProgressiveStagesEMIPlugin implements EmiPlugin {
     /** Mark the client shutdown boundary before lock caches are cleared. */
     public static void beginClientDisconnect() {
         clientDisconnecting.set(true);
+        clientSessionGeneration.incrementAndGet();
         reloadPending.set(false);
     }
 
@@ -440,6 +445,15 @@ public class ProgressiveStagesEMIPlugin implements EmiPlugin {
 
     private static boolean isReloadableClient(net.minecraft.client.Minecraft minecraft) {
         return minecraft != null && minecraft.level != null && minecraft.player != null;
+    }
+
+    private static boolean isCurrentSession(long refreshGeneration, net.minecraft.client.Minecraft minecraft) {
+        return !clientDisconnecting.get() && clientSessionGeneration.get() == refreshGeneration
+            && isReloadableClient(minecraft);
+    }
+
+    private static void clearPendingForCurrentSession(long refreshGeneration) {
+        if (clientSessionGeneration.get() == refreshGeneration) reloadPending.set(false);
     }
 
     /**

--- a/src/main/java/com/enviouse/progressivestages/client/emi/ProgressiveStagesEMIPlugin.java
+++ b/src/main/java/com/enviouse/progressivestages/client/emi/ProgressiveStagesEMIPlugin.java
@@ -42,6 +42,7 @@ public class ProgressiveStagesEMIPlugin implements EmiPlugin {
     private static boolean initialized = false;
     // Prevent rapid-fire reloads; only allow one pending reload at a time
     private static final AtomicBoolean reloadPending = new AtomicBoolean(false);
+    private static final AtomicBoolean clientDisconnecting = new AtomicBoolean(false);
 
     @Override
     public void register(EmiRegistry registry) {
@@ -381,10 +382,13 @@ public class ProgressiveStagesEMIPlugin implements EmiPlugin {
         if (!StageConfig.isEmiEnabled()) {
             return;
         }
-        if (!initialized) {
+        if (!initialized || clientDisconnecting.get()) {
             LOGGER.debug("[ProgressiveStages] EMI not initialized yet, skipping reload");
             return;
         }
+
+        var minecraft = net.minecraft.client.Minecraft.getInstance();
+        if (!isReloadableClient(minecraft)) return;
 
         // Debounce: if a reload is already pending, don't queue another
         if (!reloadPending.compareAndSet(false, true)) {
@@ -395,12 +399,11 @@ public class ProgressiveStagesEMIPlugin implements EmiPlugin {
         try {
             LOGGER.info("[ProgressiveStages] Scheduling EMI reload due to stage/lock change...");
 
-            var minecraft = net.minecraft.client.Minecraft.getInstance();
-
             // Schedule on the main render thread with a small delay to let data settle
             minecraft.execute(() -> {
                 try {
                     reloadPending.set(false);
+                    if (clientDisconnecting.get() || !isReloadableClient(minecraft)) return;
                     LOGGER.info("[ProgressiveStages] Triggering EMI reload. Current stages: {}", ClientStageCache.getStages());
 
                     // Use EmiReloadManager.reload() directly to force a full EMI reload.
@@ -422,6 +425,21 @@ public class ProgressiveStagesEMIPlugin implements EmiPlugin {
             reloadPending.set(false);
             LOGGER.error("[ProgressiveStages] Failed to schedule EMI reload: {}", e.getMessage());
         }
+    }
+
+    /** Mark the client shutdown boundary before lock caches are cleared. */
+    public static void beginClientDisconnect() {
+        clientDisconnecting.set(true);
+        reloadPending.set(false);
+    }
+
+    /** Permit viewer refreshes for a new connected client session. */
+    public static void endClientDisconnect() {
+        clientDisconnecting.set(false);
+    }
+
+    private static boolean isReloadableClient(net.minecraft.client.Minecraft minecraft) {
+        return minecraft != null && minecraft.level != null && minecraft.player != null;
     }
 
     /**

--- a/src/test/java/com/enviouse/progressivestages/client/emi/ProgressiveStagesEMIPluginTest.java
+++ b/src/test/java/com/enviouse/progressivestages/client/emi/ProgressiveStagesEMIPluginTest.java
@@ -15,13 +15,19 @@ class ProgressiveStagesEMIPluginTest {
             "src/main/java/com/enviouse/progressivestages/client/emi/ProgressiveStagesEMIPlugin.java"));
         String eventHandler = Files.readString(Path.of(System.getProperty("progressivestages.projectDir"),
             "src/main/java/com/enviouse/progressivestages/client/ClientEventHandler.java"));
+        String bridge = Files.readString(Path.of(System.getProperty("progressivestages.projectDir"),
+            "src/main/java/com/enviouse/progressivestages/client/EmiLifecycleBridge.java"));
 
         assertTrue(source.contains("private static final AtomicBoolean clientDisconnecting"));
         assertTrue(source.contains("if (!initialized || clientDisconnecting.get())"));
         assertTrue(source.contains("if (clientDisconnecting.get() || !isReloadableClient(minecraft)) return;"));
         assertTrue(source.contains("minecraft.level != null && minecraft.player != null"));
-        assertTrue(eventHandler.indexOf("ProgressiveStagesEMIPlugin.beginClientDisconnect()")
+        assertTrue(eventHandler.indexOf("EmiLifecycleBridge.beginClientDisconnect()")
             < eventHandler.indexOf("ClientStageCache.clear()"));
-        assertTrue(eventHandler.contains("ProgressiveStagesEMIPlugin.endClientDisconnect()"));
+        assertTrue(eventHandler.contains("EmiLifecycleBridge.endClientDisconnect()"));
+        assertTrue(!eventHandler.contains("client.emi.ProgressiveStagesEMIPlugin"));
+        assertTrue(bridge.contains("ModList.get().isLoaded(\"emi\")"));
+        assertTrue(bridge.contains("Class.forName(EMI_PLUGIN)"));
+        assertTrue(bridge.contains("ReflectiveOperationException | LinkageError"));
     }
 }

--- a/src/test/java/com/enviouse/progressivestages/client/emi/ProgressiveStagesEMIPluginTest.java
+++ b/src/test/java/com/enviouse/progressivestages/client/emi/ProgressiveStagesEMIPluginTest.java
@@ -1,0 +1,27 @@
+package com.enviouse.progressivestages.client.emi;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProgressiveStagesEMIPluginTest {
+
+    @Test
+    void doesNotStartOrRunARefreshAfterTheClientWorldCloses() throws Exception {
+        String source = Files.readString(Path.of(System.getProperty("progressivestages.projectDir"),
+            "src/main/java/com/enviouse/progressivestages/client/emi/ProgressiveStagesEMIPlugin.java"));
+        String eventHandler = Files.readString(Path.of(System.getProperty("progressivestages.projectDir"),
+            "src/main/java/com/enviouse/progressivestages/client/ClientEventHandler.java"));
+
+        assertTrue(source.contains("private static final AtomicBoolean clientDisconnecting"));
+        assertTrue(source.contains("if (!initialized || clientDisconnecting.get())"));
+        assertTrue(source.contains("if (clientDisconnecting.get() || !isReloadableClient(minecraft)) return;"));
+        assertTrue(source.contains("minecraft.level != null && minecraft.player != null"));
+        assertTrue(eventHandler.indexOf("ProgressiveStagesEMIPlugin.beginClientDisconnect()")
+            < eventHandler.indexOf("ClientStageCache.clear()"));
+        assertTrue(eventHandler.contains("ProgressiveStagesEMIPlugin.endClientDisconnect()"));
+    }
+}

--- a/src/test/java/com/enviouse/progressivestages/client/emi/ProgressiveStagesEMIPluginTest.java
+++ b/src/test/java/com/enviouse/progressivestages/client/emi/ProgressiveStagesEMIPluginTest.java
@@ -22,8 +22,11 @@ class ProgressiveStagesEMIPluginTest {
         assertTrue(source.contains("if (!initialized || clientDisconnecting.get())"));
         assertTrue(source.contains("if (clientDisconnecting.get() || !isReloadableClient(minecraft)) return;"));
         assertTrue(source.contains("minecraft.level != null && minecraft.player != null"));
-        assertTrue(eventHandler.indexOf("EmiLifecycleBridge.beginClientDisconnect()")
-            < eventHandler.indexOf("ClientStageCache.clear()"));
+        int disconnectBridge = eventHandler.indexOf("EmiLifecycleBridge.beginClientDisconnect()");
+        int cacheClear = eventHandler.indexOf("ClientStageCache.clear()");
+        assertTrue(disconnectBridge >= 0);
+        assertTrue(cacheClear >= 0);
+        assertTrue(disconnectBridge < cacheClear);
         assertTrue(eventHandler.contains("EmiLifecycleBridge.endClientDisconnect()"));
         assertTrue(!eventHandler.contains("client.emi.ProgressiveStagesEMIPlugin"));
         assertTrue(bridge.contains("ModList.get().isLoaded(\"emi\")"));

--- a/src/test/java/com/enviouse/progressivestages/client/emi/ProgressiveStagesEMIPluginTest.java
+++ b/src/test/java/com/enviouse/progressivestages/client/emi/ProgressiveStagesEMIPluginTest.java
@@ -19,8 +19,12 @@ class ProgressiveStagesEMIPluginTest {
             "src/main/java/com/enviouse/progressivestages/client/EmiLifecycleBridge.java"));
 
         assertTrue(source.contains("private static final AtomicBoolean clientDisconnecting"));
+        assertTrue(source.contains("private static final AtomicLong clientSessionGeneration"));
         assertTrue(source.contains("if (!initialized || clientDisconnecting.get())"));
-        assertTrue(source.contains("if (clientDisconnecting.get() || !isReloadableClient(minecraft)) return;"));
+        assertTrue(source.contains("long refreshGeneration = clientSessionGeneration.get();"));
+        assertTrue(source.contains("if (!isCurrentSession(refreshGeneration, minecraft)) return;"));
+        assertTrue(source.contains("clientSessionGeneration.incrementAndGet();"));
+        assertTrue(source.contains("clearPendingForCurrentSession(refreshGeneration);"));
         assertTrue(source.contains("minecraft.level != null && minecraft.player != null"));
         int disconnectBridge = eventHandler.indexOf("EmiLifecycleBridge.beginClientDisconnect()");
         int cacheClear = eventHandler.indexOf("ClientStageCache.clear()");


### PR DESCRIPTION
phase 004 records the verified compatibility candidate.

it fixes the emi disconnect refresh race and adds regression coverage.

local build, java tests, gametests, editor checks, packaged client smoke, packaged dedicated server smoke, and jar inspection passed.

the six baseline issues remain open pending final release evidence.