### PR TITLE
pin release validation workflow

### DIFF
--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   validate:
-    uses: MCEnvision/.github/.github/workflows/release-validation.yml@d731214d860ad2422ab8956a5d337dfaec51f64a
+    uses: MCEnvision/.github/.github/workflows/release-validation.yml@2b264b7f1b1f2c6e94f36921f5c13a3713ece48b
     with:
-      shared-ref: "d731214d860ad2422ab8956a5d337dfaec51f64a"
+      shared-ref: "2b264b7f1b1f2c6e94f36921f5c13a3713ece48b"

--- a/docs/release/3.0.4.md
+++ b/docs/release/3.0.4.md
@@ -4,6 +4,21 @@ These notes describe the verified 3.0.4 changes prepared for the final release
 candidate. Platform publication, final checksums, and release links are added only
 after the final release artifact is approved.
 
+## Release Validation
+
+The release candidate uses the immutable shared validation revision
+`2b264b7f1b1f2c6e94f36921f5c13a3713ece48b`. It builds the candidate, creates
+SHA-256 and SHA-512 inventories, generates an SPDX SBOM, and verifies both the
+build provenance and SPDX SBOM attestations against the exact reusable workflow
+and source commit.
+
+After the untouched candidate passes, the validation job creates a disposable
+one-byte-modified copy outside the retained bundle. Both attestation predicates
+must reject that copy. An accepted modified copy fails validation.
+
+This validation does not upload a file, create a platform release, or close an
+issue. CurseForge and Modrinth publication remain a separate final release step.
+
 ## Editor Corrections
 
 - The Easy Builder now distinguishes a recipe output item from an exact recipe


### PR DESCRIPTION
implements core req 009.\n\npins release validation to the immutable shared revision with provenance, spdx sbom, and tampered artifact rejection checks. documents the validation only boundary. no platform upload or issue closure occurs in this phase.